### PR TITLE
Add pkt.world pool

### DIFF
--- a/docs/mining/index.md
+++ b/docs/mining/index.md
@@ -99,6 +99,7 @@ There are currently three mining pools:
 * Pkteer: `http://pool.pkteer.com`
 * Flufpool: `http://pool.noworries.tech`
 * PKTPool: `http://pool.pktpool.io`
+* Pkt.world: `http://pool.pkt.world`
 
 Your mining revenue depends on how high the pool's fee is as well as how much hardware they are
 using in-house. You should test your daily earnings on each pool to see which one is best.


### PR DESCRIPTION
This PR adds the pkt.world pool to the list of pools.

We also provide some other links like the whotopay and chat on the pool webpage (http://pool.pkt.world), can add a hyperlink to the site? We intend to add some useful statistics to this page at a later time.