### PR TITLE
A single char is missing no more...

### DIFF
--- a/docs/mining/pool_setup_guide.md
+++ b/docs/mining/pool_setup_guide.md
@@ -192,7 +192,7 @@ url:  'http://localhost:8081',
 ```
 If allowing external annminers use a resolved address suchas:
 ```
-url: 'http://ann1.pktpool.io
+url: 'http://ann1.pktpool.io'
 ```
 ***Replace the url with your own.***
 


### PR DESCRIPTION
Fixed typo in pool_mining_guide about annHandlers using pktpool.io url