### PR TITLE
Fixes for Header and Footer to match style on pkt.cash

### DIFF
--- a/pkt/base.html
+++ b/pkt/base.html
@@ -147,14 +147,12 @@
         </div>
         <a href="https://explorer.pkt.cash/" class="header__nav-link">Block Explorer</a>
       </nav>
-      {%- block search_button %}
-      <div class="header__search" data-toggle="modal" data-target="#mkdocs_search_modal">
-        <img src="{{ 'img/icon/search.svg'|url }}" alt="" class="header__search-img">
-      </div>
-      {%- endblock %}
       <div class="link-blue link-blue__down dropdown">
         Whitepaper
-        <img src="{{ 'img/icon/arrow.svg'|url }}" alt="" class="link-blue--arrow">
+        <svg width="11" height="12" version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 284.929 284.929" xml:space="preserve" fill="#fff" class="nav__menu-blue-img" style="enable-background:new 0 0 284.929 284.929"><g><path d="M282.082,76.511l-14.274-14.273c-1.902-1.906-4.093-2.856-6.57-2.856c-2.471,0-4.661,0.95-6.563,2.856L142.466,174.441
+		L30.262,62.241c-1.903-1.906-4.093-2.856-6.567-2.856c-2.475,0-4.665,0.95-6.567,2.856L2.856,76.515C0.95,78.417,0,80.607,0,83.082
+		c0,2.473,0.953,4.663,2.856,6.565l133.043,133.046c1.902,1.903,4.093,2.854,6.567,2.854s4.661-0.951,6.562-2.854L282.082,89.647
+		c1.902-1.903,2.847-4.093,2.847-6.565C284.929,80.607,283.984,78.417,282.082,76.511z"></path></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g> <g></g></svg>
         <div class="dropdown-content">
           <a href="https://pkt.cash/PKT_Network_v1.0_2021.02.01.pdf" target="_blank">Whitepaper</a>
           <a href="https://docsend.com/view/ayf5d3tz5rymn8fv" target="_blank">Deck</a>
@@ -192,9 +190,9 @@
     {% if not config.theme.disable_footer_except_revision %}
     <div class="container-footer">
       <div class="footer__wrap">
-        <div class="footer__logo">
+		<a href="https://pkt.cash" class="footer__logo">
           <img src="{{'img/logo-footer.svg'|url}}" alt="">
-        </div>
+        </a>
         <div class="footer__links">
           <div class="footer__links-one">
             <h4 class="footer__links-title">Quicklinks</h4>

--- a/pkt/css/base.css
+++ b/pkt/css/base.css
@@ -346,8 +346,7 @@ h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .head
 /* Header */
 header {
     padding: 12px 0;
-    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.25);
-    height: 80px;
+    height: auto;
     position: sticky;
     top: 0;
     background-color: #fff;
@@ -363,12 +362,14 @@ header {
   @media (max-width: 600px) {
     header {
       padding: 15px 0;
-      height: 60px;
     }
   }
   
   .container-header {
-    margin: 0 80px;
+    width: 100%;
+    max-width: 1255px;
+    margin: 0 auto;
+    padding: 0;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -393,6 +394,11 @@ header {
     justify-content: center;
     align-items: center;
     flex-shrink: 0;
+  }
+  .header__logo img {
+	height: 45px;
+    width: auto;
+    margin-left: 5px;
   }
   
   @media (max-width: 800px) {
@@ -486,13 +492,11 @@ header {
     display: flex;
     justify-content: center;
     align-items: center;
-  
-    padding: 10px 20px;
+    padding: 15px 46px;
     margin-left: 10px;
-  
-    font-size: 17px;
-    line-height: 35px;
-    font-weight: 700;
+    font-size: 14px;
+    line-height: 1;
+    font-weight: 400;
     color: #fff;
     background-color: #3CADEF;
     border-radius: 34px;


### PR DESCRIPTION
Fixed link to https://pkt.cash/ website for Footer logo. 
Style changes for header elements to match more header on https://pkt.cash/:
 - Logo size
 - Search element
 - Whitepaper button fixes
 - Header size and margins fixes