### PR TITLE
Revise pktwallet mining sections

### DIFF
--- a/docs/mining/index.md
+++ b/docs/mining/index.md
@@ -17,78 +17,24 @@ done from anywhere.
 
 ## How to Announcement mine
 
-You can either:
-* [Install on your local machine](#install-on-your-local-machine), or
-* [Intall the docker image](#install-the-docker-image)
+Pre-built packetcrypt binaries (for linux) or installation packages (for macos) and archives (for windows) can be downloaded from [packetcrypt_rs releases page](https://github.com/cjdelisle/packetcrypt_rs/releases/).
 
-### Install on your local machine
-
-#### Install the dependencies
-
-* On Debian or Ubuntu: `sudo apt install gcc git`
-* On Fedora or RedHat: `sudo dnf install gcc git`
-* On Alpine Linux: `sudo apk add gcc git`
-
-##### Specifics for Azure App Service Linux
-When using [Azure App Service Linux](https://docs.microsoft.com/en-us/azure/app-service/overview#app-service-on-linux) you may need a special process.
-
-```
-apt update
-apt install apt-utils
-apt upgrade
-apt install pkg-config
-apt install file
-apt install gcc git
-```
-
-On Azure, you may need to remove .bashrc and .profile to resolve [this build error](https://github.com/sodiumoxide/sodiumoxide/issues/460).
-
-```
-rm ~/.bashrc
-rm ~/.profile
-```
-
-#### Install Rust
-It is important to install Rust using rustup because packaged Rust is often out of date and
-compiling will fail. Run the following command *as the user who will be mining*.
-
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-    
-##### Install Make
-
-    apt install make    
-
-#### Download PacketCrypt
-
-    git clone https://github.com/cjdelisle/packetcrypt_rs
-
-#### Compile PacketCrypt
-
-    cd packetcrypt_rs
-    ~/.cargo/bin/cargo build --release
+For windows, download the zip archive suffixed with `-windows.zip` before extracting its content.
+For macos, download the package suffixed with `.pkg` before clicking on its icon in the Finder for installation.
+For linux, download the binary suffixed with `-linux_amd64` and rename it `packetcrypt`.
 
 #### Begin Announcement Mining
 To begin mining, you will need the address of your wallet and you will need to choose a pool. You cannot mine into the electrum wallet. You can only mine into the [Command Line Wallet](https://docs.pkt.cash/en/latest/pktd/pktwallet/) or the [Mac GUI Wallet](https://github.com/artrepreneur/PKT-Cash-Wallet/releases). You cannot mine into the electrum wallet, so do not try.
 
-    ./target/release/packetcrypt ann -p <your_wallet_address> http://your.pool.of.choice
+    packetcrypt ann -p <your_wallet_address> pool_1 [pool_2 pool_3 pool_4]
+    
+    or for windows
 
-### Install the Docker image
+    packetcrypt.exe ann -p <your_wallet_address> pool_1 [pool_2 pool_3 pool_4]
 
-Installing the Docker image is easy.
+Announcement mining can be done into a single pool or multiple pools. When you announcement mine into multiple pools, you will be paid by each pool that you submit annoucements to.
 
-First, install [Docker](https://www.docker.com/)
-
-Then, install the [PKT Miner Docker image](https://hub.docker.com/r/backupbrain/packetcrypt) by running this command in your terminal or CMD:
-
-```bash
-$ docker pull backupbrain/packetcrypt
-```
-
-Then, pick a pool and mine. Make sure you have a wallet to mine into.
-
-```bash
-$ docker run backupbrain/packetcrypt ann -p <pkt_address> <pool_url>
-```
+pool_1 is the pool running the highest difficulty. If you notice problems, you can test listing the pools in a different order. The number of pools you mine into is at your discretion. If a pool is down or malfunctioning you will notice the pool is not mining at [100%] in your mining feed and you can choose to remove the under-performing or malfunctioning pool. 
 
 ## Choosing a Mining Pool
 There are currently several mining pools:
@@ -100,18 +46,6 @@ There are currently several mining pools:
 * Flufpool: `http://noworries.tech/pool`
 
 You should test our daily earnings on each pool to see which one is best. Your mining revenue depends non how much each pool allocates towards announcement miners as well as how much hardware they are using in-house. 
-
-## Multi-Pool Announcement Mining
-Announcement mining can be done into a single pool or multiple pools. When you announcement mine into multiple pools, you will be paid by each pool that you submit annoucements to.
-
-If you want to mine into multiple pools, you will need to update your software to the packetcrypt develop branch, as follows:
-
-    git clone https://github.com/cjdelisle/packetcrypt_rs --branch develop
-    cd packetcrypt_rs
-    ~/.cargo/bin/cargo build --release
-    ./target/release/packetcrypt ann -p <your_wallet_address> pool_1 pool_2 pool_3 pool_4
-
-pool_1 is the pool running the highest difficulty. If you notice problems, you can test listing the pools in a different order. The number of pools you mine into is at your discretion. If a pool is down or malfunctioning you will notice the pool is not mining at [100%] in your mining feed and you can choose to remove the under-performing or malfunctioning pool. 
 
 ## Block Mining & Running a Pool
 Because each block miner must use as much bandwidth as all of the announcement miners *combined*,

--- a/docs/mining/index.md
+++ b/docs/mining/index.md
@@ -17,18 +17,21 @@ done from anywhere.
 
 ## How to Announcement mine
 
-Pre-built packetcrypt binaries (for linux) or installation packages (for macos) and archives (for windows) can be downloaded from [packetcrypt_rs releases page](https://github.com/cjdelisle/packetcrypt_rs/releases/).
+Pre-built packetcrypt binaries (for linux) or installation packages (for macos) and archives (for windows) can be downloaded from [packetcrypt releases page](https://github.com/cjdelisle/packetcrypt_rs/releases/).
 
-For windows, download the zip archive suffixed with `-windows.zip` before extracting its content.
-For macos, download the package suffixed with `.pkg` before clicking on its icon in the Finder for installation.
-For linux, download the binary suffixed with `-linux_amd64` and rename it `packetcrypt`.
+ * For **windows**, download the zip archive suffixed with `-windows.zip`  
+ and extract its content.
+ * For **macos**, download the package suffixed with `.pkg`  
+ and click on its icon in the Finder for installation.
+ * For **linux**, download the binary suffixed with `-linux_amd64` 
+ and rename it `packetcrypt`.
 
 #### Begin Announcement Mining
 To begin mining, you will need the address of your wallet and you will need to choose a pool. You cannot mine into the electrum wallet. You can only mine into the [Command Line Wallet](https://docs.pkt.cash/en/latest/pktd/pktwallet/) or the [Mac GUI Wallet](https://github.com/artrepreneur/PKT-Cash-Wallet/releases). You cannot mine into the electrum wallet, so do not try.
 
     packetcrypt ann -p <your_wallet_address> pool_1 [pool_2 pool_3 pool_4]
     
-    or for windows
+    [or for windows]
 
     packetcrypt.exe ann -p <your_wallet_address> pool_1 [pool_2 pool_3 pool_4]
 

--- a/docs/pktd/pktwallet.md
+++ b/docs/pktd/pktwallet.md
@@ -6,19 +6,26 @@ For an easy-to-use wallet which works on Windows, Mac and Linux, see [PKT Electr
 but **electrum is not appropriate for mining**.
 
 ## Installation and setup
-### Microsoft Windows
-If you are on Windows:
 
-* Download [pktwallet.exe](https://drive.google.com/file/d/15H-kP3H7MiXS_C6no9PouoNaE7iYypUY/view?usp=sharing)
-* Download [pktctl.exe](https://drive.google.com/file/d/1ixKkHavB8C9Ny8JxJwwT8nIfJ4t9dI__/view?usp=sharing)
-* Open the command prompt
-* Type `cd Downloads`
-* Follow the instructions but
-  * In place of `./bin/pktwallet`, type `pktwallet*.exe`
-  * In place of `./bin/pktctl`, type `pktctl*.exe`
+### Microsoft Windows
+ - Download the most recent zip archive suffixed with `-windows.zip` available from [pktd releases page](https://github.com/pkt-cash/pktd/releases)(pktd-v1.3.1-windows.zip, for example)
+ - Go to the `Downloads` directory (or where the archive as been saved)
+ - Unarchive the content of the zip file
+ - Open the command prompt
+ - Type `cd Downloads`
+ - Follow the instructions but
+   - In place of `./bin/pktwallet`, type `./bin/pktwallet*.exe`
+   - In place of `./bin/pktctl`, type `./bin/pktctl*.exe`
 
 ### MacOS and Linux
-Follow the [installation](../#installation) process. Then once it is installed, you can create your wallet.
+ - Download one of the most recent packages available for linux or macos available from [pktd releases page](https://github.com/pkt-cash/pktd/releases)
+  
+  For example and by considering the most recent packages available are those which have been pre-built for `pktd-v1.3.1`:
+
+  For macos, after having downloaded `pktd-v1.3.1-macos.pkg`, click on the package icon in the Finder to install the wallet
+
+  For linux and depending on your distribution `pktd-v1.3.1-linux.deb` (Debian or Ubuntu) or `pkt-v1.3.1-linux.rpm` (Fedora or RedHat) can be downloaded
+  before installing the wallet from the graphical user interface or the command-line.
 
 ## Creating a wallet
 To create a new PKT wallet, use the pktwallet --create command:

--- a/docs/pktd/pktwallet.md
+++ b/docs/pktd/pktwallet.md
@@ -8,24 +8,33 @@ but **electrum is not appropriate for mining**.
 ## Installation and setup
 
 ### Microsoft Windows
- - Download the most recent zip archive suffixed with `-windows.zip` available from [pktd releases page](https://github.com/pkt-cash/pktd/releases)(pktd-v1.3.1-windows.zip, for example)
- - Go to the `Downloads` directory (or where the archive as been saved)
+ - Download the most recent zip archive suffixed with `-windows.zip` available from   
+ [pktd releases page](https://github.com/pkt-cash/pktd/releases) 
+ 
+ For example: `pktd-v1.3.1-windows.zip`
+
+ - Go to the `Downloads` directory
  - Unarchive the content of the zip file
  - Open the command prompt
  - Type `cd Downloads`
- - Follow the instructions but
-   - In place of `./bin/pktwallet`, type `./bin/pktwallet*.exe`
-   - In place of `./bin/pktctl`, type `./bin/pktctl*.exe`
+ - Follow the instructions below but
+    - In place of `./bin/pktwallet`, type `./bin/pktwallet.exe`
+    - In place of `./bin/pktctl`, type `./bin/pktctl.exe`
 
 ### MacOS and Linux
- - Download one of the most recent packages available for linux or macos available from [pktd releases page](https://github.com/pkt-cash/pktd/releases)
+ - Download one of the most recent packages available for linux or macos from  
+ [pktd releases page](https://github.com/pkt-cash/pktd/releases)
   
-  For example and by considering the most recent packages available are those which have been pre-built for `pktd-v1.3.1`:
+  For example, for `pktd-v1.3.1` release:
 
-  For macos, after having downloaded `pktd-v1.3.1-macos.pkg`, click on the package icon in the Finder to install the wallet
+ - For **MacOS**, after having downloaded `pktd-v1.3.1-macos.pkg`,  
+install `pktwallet` and other utilities by clicking on the package icon in the Finder.
 
-  For linux and depending on your distribution `pktd-v1.3.1-linux.deb` (Debian or Ubuntu) or `pkt-v1.3.1-linux.rpm` (Fedora or RedHat) can be downloaded
-  before installing the wallet from the graphical user interface or the command-line.
+ - For **Linux**, after having downloaded one of the following packages:  
+     - `pktd-v1.3.1-linux.deb` (Debian or Ubuntu) or  
+     - `pktd-v1.3.1-linux.rpm` (Fedora or RedHat),  
+    install `pktwallet` and other utilities by clicking
+    on the appropriate package icon or running an installation command
 
 ## Creating a wallet
 To create a new PKT wallet, use the pktwallet --create command:


### PR DESCRIPTION
# Description

 - `How to Announcement mine` and `Multi-Pool Announcement Mining` sections have been merged
 - The documentation invite pkteers to download pre-built binaries or packages for linux, zip archive for windows and packaged binaries for macos installing of compiling `packetcrypt` or `pktd` utilities like `pktwallet` from source
