### PR TITLE
Added a link to the Pkt.world wallet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ There are several wallets which you can choose from, the easiest to set up are
 
 * [PKT Electrum](./electrum) which has a Graphical UI and supports Windows, Mac and Linux.
 * [PKT Wallet](./pktwalletgui) which has a Graphical UI and supports MacOS and works great with miners.
+* [Pkt.world Wallet](https://www.pkt.world/wallet) which has a Graphical UI for Windows, works with miners and includes a built-in miner.
 
 You can also setup [PKT Wallet](./pktd/pktwallet) which is command line only but has greater
 scalability and privacy features.


### PR DESCRIPTION
The documentation for the Pkt.world wallet is currently limited and it is not yet open source, but with the number of users running into problems with other (Windows) wallets I think it might be good to have it listed here.